### PR TITLE
Bump Security String to 2020-01-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-12-05
+      PLATFORM_SECURITY_PATCH := 2020-01-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0001   A-140055304  EoP    Moderate   10
                             EoP    High       8.0, 8.1, 9
CVE-2020-0002   A-142602711  RCE    Moderate   10
                             RCE    Critical   8.0, 8.1, 9
CVE-2020-0004   A-120847476  DoS    High       8.0, 8.1, 9, 10
CVE-2020-0006   A-139738828  ID     High       8.0, 8.1, 9, 10
CVE-2020-0007   A-141890807  ID     High       8.0, 8.1, 9, 10
CVE-2020-0008   A-142558228  ID     High       8.0, 8.1, 9, 10

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0003   A-140195904  EoP    High       8.0

Implemented (Qualcomm):
=======================
CVE:            References:    Type:  Severity:  Component:
CVE-2019-10581  A-142267478    N/A    High       Audio
                QC-CR#2451619

Change-Id: Ief7a839137040a9e6abaf6431dde9a1266069dcc